### PR TITLE
Fix black QuickWidget DocumentList when opening feature form

### DIFF
--- a/document_management_system/gui/relation_editor_feature_side_widget.py
+++ b/document_management_system/gui/relation_editor_feature_side_widget.py
@@ -410,7 +410,7 @@ class RelationEditorFeatureSideWidget(QgsAbstractRelationEditorWidget, WidgetUi)
         if self.nmRelation().isValid():
             layer = self.nmRelation().referencedLayer()
 
-        showDocumentFormDialog = QgsAttributeDialog(layer, layer.getFeature(self._currentDocumentId), False, self, True)
+        showDocumentFormDialog = QgsAttributeDialog(layer, layer.getFeature(self._currentDocumentId), False, self.parent(), True)
         showDocumentFormDialog.exec()
         self.updateUi()
 


### PR DESCRIPTION
Happen only on windows
Fix by using the parent of parent as parent
Related to Qt bug https://bugreports.qt.io/browse/QTBUG-40765